### PR TITLE
Fix bad body encoding and allow list of intervals

### DIFF
--- a/src/Serializers/JsonSerializer.php
+++ b/src/Serializers/JsonSerializer.php
@@ -6,12 +6,16 @@ use Smuuf\CeleryForPhp\Interfaces\ISerializer;
 
 class JsonSerializer implements ISerializer {
 
+	private const JSON_ENCODE_FLAGS
+		= JSON_THROW_ON_ERROR
+		| JSON_INVALID_UTF8_SUBSTITUTE;
+
 	public function getContentType(): string {
 		return "application/json";
 	}
 
 	public function encode(mixed $input): string {
-		return json_encode($input, JSON_UNESCAPED_SLASHES);
+		return json_encode($input, self::JSON_ENCODE_FLAGS);
 	}
 
 	/**

--- a/tests/suite/JsonSerializer.phpt
+++ b/tests/suite/JsonSerializer.phpt
@@ -1,0 +1,25 @@
+<?php
+
+use Tester\Assert;
+
+use Smuuf\CeleryForPhp\Serializers\JsonSerializer;
+
+require __DIR__ . '/../bootstrap.php';
+
+$s = new JsonSerializer();
+
+//
+// Serializing JSOn with broken unicode doesn't fail completely.
+// Broken unicode will be substituted with "\ufffd" (REPLACEMENT CHARACTER).
+//
+
+$brokenUnicode = "\xC3Hello";
+Assert::same('"\ufffdHello"', $s->encode("\xC3Hello"));
+
+//
+// JSON encoded crashes if the encoding is not successful, instead of returning
+// false.
+//
+
+$unEncodable = [STDERR]; // File descriptor cannot be JSON-encoded.
+Assert::exception(fn() => $s->encode($unEncodable), \JsonException::class);


### PR DESCRIPTION
## Fix: Avoid empty string as body of task message when posting tasks

`json_encode($body)` could return empty string, so the task's JSON could contain `"body": ""`, which is catastrophic - Celery can't decode that message and crashes - and the message is kept in the queue, causing crashes again and again.

This could happen, for example, if any of the task arguments was a string that contained badly formed Unicode characters.

Now we:
- Replace (tell json_encode() to) badly formed Unicode with "\ufffd" (REPLACEMENT CHARACTER).
- For other problems with json_encoding we're strict and we'll throw `JsonException`.

## Feature: AsyncResult::get()'s interval argument can now be a list
E.g. for interval specified as `[0.1, 0.6, 10]` we'll first wait 0.1s, then 0.6s, then 10s repeatedly, until the task is ready (or we time out).